### PR TITLE
Closing time

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To close a running server (e.g., to deploy a new version), use `kill`:
 
 As the process closes,
 
-  * New connections will be refused
+  * New connections will receive a 502 (Bad Gateway)
 
   * All existing connections will remain open until responses can be
       served or the timeout is reached

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = function (appHandler, opts) {
 
     _isClosing = true;
 
+    httpServer.emit('closing');
     httpServer.close();
 
     killTimer = setTimeout(function () {

--- a/test/index.js
+++ b/test/index.js
@@ -75,8 +75,8 @@ test('handles existing requests when failing', function (t) {
   });
 });
 
-test('rejects new connections when failing', function (t) {
-  t.plan(6);
+test('shows bad gateway while closing', function (t) {
+  t.plan(7);
 
   forkServer(function (err, server) {
     t.error(err, 'Opening server');
@@ -94,20 +94,21 @@ test('rejects new connections when failing', function (t) {
     });
 
     setTimeout(function () {
-      server.get('/ok', function (err) {
-        t.equal(err.code, 'ECONNREFUSED', 'rejects new connection');
+      server.get('/ok', function (err, body) {
+        t.error(err);
+        t.equal(body, 'Bad Gateway');
       });
     }, 50);
   });
 });
 
-test('rejects new connections when SIGTERMd', function (t) {
-  t.plan(4);
+test('shows bad gateway after SIGTERM', function (t) {
+  t.plan(5);
 
   forkServer(function (err, server) {
     t.error(err, 'Opening server');
 
-    // Will keep server alive for 1s
+    // Keep server alive
     server.get('/wait?ms=100', function (err, body) {
       t.error(err);
       t.equal(body, 'RESUMED');
@@ -118,8 +119,9 @@ test('rejects new connections when SIGTERMd', function (t) {
     }, 20);
 
     setTimeout(function () {
-      server.get('/ok', function (err) {
-        t.equal(err.code, 'ECONNREFUSED', 'rejects new connection');
+      server.get('/ok', function (err, body) {
+        t.error(err);
+        t.equal(body, 'Bad Gateway');
       });
     }, 50);
   });


### PR DESCRIPTION
Ease-of-use updates for the benefit of upstream apps:
1. a `'closing'` event is now emitted as the server begins to close
2. new requests will receive a 502 while the server is closing (connections were previously rejected)
