### PR TITLE
Exposes `closingHandler`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ server.close();
 
 Options:
 
-  * `timeout` `Number` - the time (ms) to wait for connections
-    to close before forcing a hard shutdown. Defaults to `10000`.
+  * `timeout` `Number` - the time (ms) to wait for connections to close before
+      forcing a hard shutdown. Default: `10000`.
+
+  * `closingHandler` `Function` - a `(req, res)` handler for requests received
+      while the server is shutting down. Default: `leadballoon.sendUnavailable`.
 
 Events:
 

--- a/README.md
+++ b/README.md
@@ -3,17 +3,14 @@ Lead Balloon
 
 [![Build Status](https://travis-ci.org/rjz/leadballoon.svg?branch=master)](https://travis-ci.org/rjz/leadballoon)
 
-Wraps an instance of `http.Server` with logic to gracefully close out in
-response to an internal error, programmatic termination, or a SIGTERM.
+Wraps `http.Server` with graceful shutdown logic. Useful for ensuring service
+within fail-fast applications.
 
-As the server closes,
+With its default configuration, a `LeadBalloon` server will close out by:
 
-  * The `'closing'` event is fired
-
-  * New connections will receive a 502 (Bad Gateway)
-
-  * All existing connections will remain open until responses can be
-      served or the timeout is reached
+  1. Emitting a `'closing'` event
+  2. Servicing all existing requests (subject to a timeout)
+  3. Sending a 502 (Bad Gateway) response to any new requests
 
 When the process finishes closing, this server will emit the usual `'close'`
 event with no arguments (served closed gracefully) or an error (some connections


### PR DESCRIPTION
Some applications need to send custom responses (e.g., a redirect to an accessible server) during shutdown. This change exposes the `closingHandler` option to enable dev-land overrides of the default bad gateway response.
